### PR TITLE
Version 0.4

### DIFF
--- a/apocalypse/apk_differ.py
+++ b/apocalypse/apk_differ.py
@@ -23,9 +23,9 @@ class APKDiffer:
     def filter_class(cls: lief.DEX.Class) -> bool:
         return True
 
-    def __init__(self, passes=5, class_filtering_function=None, encoder=DefaultEncoder):
+    def __init__(self, class_filtering_function=None, encoder=DefaultEncoder):
         self._classes_differ = ClassesDiffer(
-            passes, class_filtering_function, encoder)
+            class_filtering_function, encoder)
 
         # parsed dexs are stored while diffing is ongoing, in order to prevent GC which segfaults
         self._dexs = []

--- a/apocalypse/classes_differ.py
+++ b/apocalypse/classes_differ.py
@@ -15,8 +15,7 @@ class ClassesDiffer:
     def filter_class(cls: lief.DEX.Class) -> bool:
         return cls.index != 4294967295  # filter out external classes
 
-    def __init__(self, passes=5, class_filtering_function=None, encoder=DefaultEncoder):
-        self._passes = passes
+    def __init__(self, class_filtering_function=None, encoder=DefaultEncoder):
         if class_filtering_function is None:
             class_filtering_function = self.filter_class
         self._class_filtering_function = class_filtering_function
@@ -32,11 +31,11 @@ class ClassesDiffer:
         successful_mappings = 0
         self._encoder.set_mapping({}, {})
 
-        for i in range(self._passes):
+        for i, precision in enumerate(self._encoder.get_stages()):
             old_encoding = [self._encoder.encode_old_class(
-                cls) for cls in old_classes]
+                cls, precision) for cls in old_classes]
             new_encoding = [self._encoder.encode_new_class(
-                cls) for cls in new_classes]
+                cls, precision) for cls in new_classes]
             
             mapping, reverse_mapping = heckel_diff(old_encoding, new_encoding)
 

--- a/apocalypse/cli.py
+++ b/apocalypse/cli.py
@@ -15,10 +15,11 @@ def main(verbose):
 
 @main.command()
 @click.argument('name')
-def init(name: str):
+@click.option('--format', type=click.Choice(['APK', 'DEX']), default='APK')
+def init(name: str, format: str):
     """Initialize a new timeline. 
     """
-    timeline.init(name)
+    timeline.init(name, format)
 
 @main.command()
 @click.argument('version')

--- a/apocalypse/dex_differ.py
+++ b/apocalypse/dex_differ.py
@@ -16,9 +16,9 @@ class DexDiffer:
     def filter_class(cls: lief.DEX.Class) -> bool:
         return True
 
-    def __init__(self, passes=5, class_filtering_function=None, encoder=DefaultEncoder):
+    def __init__(self, class_filtering_function=None, encoder=DefaultEncoder):
         self._classes_differ = ClassesDiffer(
-            passes, class_filtering_function, encoder)
+            class_filtering_function, encoder)
 
     def diff(self, old_dex_path: str, new_dex_path: str):
         old_dex = lief.DEX.parse(old_dex_path)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='apocalypse',
-    version='0.3',
+    version='0.4',
     packages=['apocalypse'],
     install_requires=[
         'lief',


### PR DESCRIPTION
* Fix CLI (by fixing timeline)
* Replace pass count with encoder defined stages (begins work on #11)
  * Each stage is an extra pass
  * The encoder can behave differently at every stage
  * The default encoder now successfully handles code changes _inside_ functions in its later stages